### PR TITLE
fix(typo): Fix typo in Setar Fort Heating mission

### DIFF
--- a/data/korath/korath missions.txt
+++ b/data/korath/korath missions.txt
@@ -119,7 +119,7 @@ mission "Setar Fort Heating"
 	on complete
 		payment 5000
 		conversation
-			`When you arrive on <planet>, a group of Korath is waiting to unload the cargo. You try and imitate their gesture of greeting, holding your hands up with your palms toward the group. The look surprised but hiss approvingly.`
+			`When you arrive on <planet>, a group of Korath is waiting to unload the cargo. You try and imitate their gesture of greeting, holding your hands up with your palms toward the group. They look surprised but hiss approvingly.`
 			`	Soon, all the supplies are off of your ship. The Korath give you a gesture of appreciation, then they begin unpacking it right in the middle of the spaceport. Already, a crowd has begun to gather around the equipment. It looks like it will be put to good use here. When you return to your ship, you see the Wanderer who offered you the job has transferred you your payment of <payment>.`
 			
 mission "Korath Family to Ringworld"


### PR DESCRIPTION
## Summary

Fixed one small typo in the on complete conversation text of the "Setar Fort Heating" mission.
